### PR TITLE
Keep state of each trace in a hash map

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -135,8 +135,8 @@ mod tests {
             start: duration_to_nanos(span.start.duration_since(UNIX_EPOCH).unwrap()),
             duration: duration_to_nanos(span.duration),
             error: 0,
-            meta: meta,
-            metrics: metrics,
+            meta,
+            metrics,
         };
         let raw_span = RawSpan::from_span(&span, &config.service, &config.env);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,14 +3,10 @@ use hyper::method::Method;
 use hyper::header::{ContentLength, Headers};
 use log::{debug, error, trace, warn};
 use serde_json::to_string;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex, RwLock};
 
 use crate::{api::RawSpan, model::Span};
-
-#[derive(Debug, Clone)]
-pub struct DatadogTracing {
-    buffer_sender: Arc<Mutex<mpsc::Sender<Span>>>,
-}
+use std::collections::{LinkedList, HashMap};
 
 /// Configuration settings for the client.
 #[derive(Debug)]
@@ -36,6 +32,132 @@ impl Default for Config {
     }
 }
 
+#[derive(Clone, Debug)]
+enum SpanState {
+    SpanStart(u64, u64),
+    SpanEnd(Span)
+}
+
+#[derive(Clone, Debug)]
+struct SpanStack {
+    completed_spans: Vec<Span>,
+    current_span_stack: LinkedList<u64>
+}
+
+impl SpanStack {
+    fn new() -> Self {
+        SpanStack {
+            completed_spans: vec![],
+            current_span_stack: LinkedList::new()
+        }
+    }
+
+    // Open a span by pushing the ID on the "current" span stack.
+    fn start_span(&mut self, id: u64) {
+        self.current_span_stack.push_back(id);
+    }
+
+    // Move span to "completed" and return true if it's time to send, or false to keep
+    // buffering the spans.  Unless already set, automatically set the span's parent if there are
+    // still "current" spans after popping the current one (indicating that the next on the
+    // stack is the current span's "parent").
+    fn end_span(&mut self, span: Span) -> bool {
+        if let Some(span_id) = self.current_span_stack.pop_back() {
+            let add_span = Span {
+                parent_id: span.parent_id
+                    .or_else(||
+                        self.current_span_stack.back().map(|i| i.clone())
+                    ),
+                ..span
+            };
+            debug!("Pushing span to completed: {:?}", add_span);
+            self.completed_spans.push(add_span);
+        }
+        return self.current_span_stack.is_empty()
+    }
+}
+
+struct SpanStorage {
+    inner: RwLock<HashMap<u64, SpanStack>>
+}
+
+impl SpanStorage {
+    fn new() -> Self {
+        SpanStorage {
+            inner: RwLock::new(HashMap::new())
+        }
+    }
+
+    // Either start a new trace with the span's trace ID (if there is no spans already
+    // pushed for that trace ID), or push the span on the "current" stack of spans for that
+    // trace ID.
+    fn start_span(&mut self, trace_id: u64, span_id: u64) {
+        let mut inner = self.inner.write().unwrap();
+        if let Some(ref mut ss) = inner.get_mut(&trace_id) {
+            debug!("Starting span: {}", span_id);
+            ss.start_span(span_id);
+        } else {
+            let mut new_stack = SpanStack::new();
+            new_stack.start_span(span_id);
+            debug!("Starting trace for span: {}", span_id);
+            inner.insert(trace_id, new_stack);
+        }
+    }
+
+    // Check if there's a trace for this span's trace ID.  If so, pop the span (which will send
+    // the trace if there are no more spans).  If the current span list is empty after the
+    // pop, then pop the entire SpanStack and return it (consuming so we can free memory).
+    fn end_span(&mut self, span: Span) -> Option<SpanStack>{
+        let trace_id = span.trace_id;
+        let drop_stack = {
+            let mut inner = self.inner.write().unwrap();
+            if let Some(ref mut ss) = inner.get_mut(&trace_id) {
+                debug!("Ending span: {:?}", span);
+                ss.end_span(span)
+            } else {
+                false
+            }
+        };
+        if drop_stack {
+            debug!("Dropping trace stack and returning for: {}", trace_id);
+            self.inner.write().unwrap().remove(&trace_id)
+        } else {
+            None
+        }
+    }
+
+}
+
+fn trace_server_loop(client: DdAgentClient, buffer_receiver: mpsc::Receiver<SpanState>) {
+    let mut storage = SpanStorage::new();
+
+    loop {
+        let client = client.clone();
+
+        match buffer_receiver.try_recv() {
+            Ok(SpanState::SpanStart(trace_id, span_id)) => {
+                storage.start_span(trace_id, span_id);
+            },
+            Ok(SpanState::SpanEnd(info)) => {
+                debug!("End span: {:?}", info);
+                if let Some(stack) = storage.end_span(info) {
+                    client.send(stack);
+                }
+            },
+            Err(mpsc::TryRecvError::Disconnected) => {
+                warn!("Tracing channel disconnected, exiting");
+                return;
+            },
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DatadogTracing {
+    buffer_sender: Arc<Mutex<mpsc::Sender<SpanState>>>,
+}
+
 impl DatadogTracing {
     pub fn new(config: Config) -> DatadogTracing {
         let (buffer_sender, buffer_receiver) = mpsc::channel();
@@ -49,21 +171,7 @@ impl DatadogTracing {
 
         std::thread::spawn(move || {
             println!("Starting loop");
-            loop {
-                let client = client.clone();
-
-                match buffer_receiver.try_recv() {
-                    Ok(info) => {
-                        debug!("Pulled span: {:?}", info);
-                        client.send(info);
-                    }
-                    Err(mpsc::TryRecvError::Disconnected) => {
-                        warn!("Tracing channel disconnected, exiting");
-                        return;
-                    }
-                    _ => {}
-                }
-            }
+            trace_server_loop(client, buffer_receiver);
         });
 
         DatadogTracing {
@@ -71,17 +179,16 @@ impl DatadogTracing {
         }
     }
 
-    pub fn send(&self, info: Span) -> Result<(), ()> {
-        match self.buffer_sender.lock().unwrap().send(info) {
-            Ok(_) => {
-                debug!("trace enqueued");
-                Ok(())
-            }
-            Err(err) => {
-                warn!("could not enqueue trace: {:?}", err);
-                Err(())
-            }
-        }
+    pub fn start_span(&self, trace_id: u64, span_id: u64) -> Result<(), ()> {
+        self.buffer_sender.lock().unwrap().send(SpanState::SpanStart(trace_id, span_id))
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    pub fn end_span(&self, info: Span) -> Result<(), ()> {
+        self.buffer_sender.lock().unwrap().send(SpanState::SpanEnd(info))
+            .map(|_| ())
+            .map_err(|_| ())
     }
 }
 
@@ -94,9 +201,16 @@ struct DdAgentClient {
 }
 
 impl DdAgentClient {
-    fn send(self, info: Span) {
-        let span = vec![vec![RawSpan::from_span(&info, &self.service, &self.env)]];
-        match to_string(&span) {
+    fn send(self, stack: SpanStack) {
+        debug!("Sending stack to datadog: {:?}", stack);
+        let spans: Vec<Vec<RawSpan>> = vec![
+            stack.completed_spans
+                .into_iter()
+                .map(|s| RawSpan::from_span(&s, &self.service, &self.env))
+                .collect()
+        ];
+        debug!("Sending stack to datadog: {:?}", spans);
+        match to_string(&spans) {
             Err(e) => warn!("Couldn't encode payload for datadog: {:?}", e),
             Ok(payload) => {
                 debug!("Sending to localhost agent payload: {:?}", payload);
@@ -145,7 +259,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let trace_id = rng.gen::<u64>();
         let parent_span_id = rng.gen::<u64>();
-        let span = Span {
+        let pspan = Span {
             id: parent_span_id.clone(),
             trace_id: trace_id.clone(),
             name: String::from("request"),
@@ -162,7 +276,8 @@ mod tests {
             sql: None,
             tags: HashMap::new(),
         };
-        client.send(span).unwrap();
+        client.start_span(pspan.trace_id, pspan.id).unwrap();
+
         let span = Span {
             id: rng.gen::<u64>(),
             trace_id,
@@ -180,7 +295,12 @@ mod tests {
             sql: None,
             tags: HashMap::new(),
         };
-        client.send(span).unwrap();
-        ::std::thread::sleep(::std::time::Duration::from_millis(500));
+        client.start_span(span.trace_id, span.id).unwrap();
+
+        client.end_span(span).unwrap();
+
+        client.end_span(pspan).unwrap();
+
+        ::std::thread::sleep(::std::time::Duration::from_millis(1000));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -62,17 +62,17 @@ impl SpanStack {
     // still "current" spans after popping the current one (indicating that the next on the
     // stack is the current span's "parent").
     fn end_span(&mut self, span: Span) -> bool {
-        if let Some(span_id) = self.current_span_stack.pop_back() {
+        if self.current_span_stack.pop_back().is_some() {
             let add_span = Span {
                 parent_id: span
                     .parent_id
-                    .or_else(|| self.current_span_stack.back().map(|i| i.clone())),
+                    .or_else(|| self.current_span_stack.back().map(|i| *i)),
                 ..span
             };
             debug!("Pushing span to completed: {:?}", add_span);
             self.completed_spans.push(add_span);
         }
-        return self.current_span_stack.is_empty();
+        self.current_span_stack.is_empty()
     }
 }
 


### PR DESCRIPTION
Push to a span stack when a span is started and pop when the span is
completed.  Keep track of each completed span and when the stack is
empty (all spans have been ended), send the whole vector to datadog.

The span stacks are blocked by an RW lock and are also
mutable/consuming, so memory should not grow during operation (completed
spans are removed from the hashmap, and are freed).