### PR TITLE
Major refactoring to support tokio/rs-tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ filter-logger = "*"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = "0.2.4"
+tracing-futures = "*"
 
 [dev-dependencies]
 rand = "0.3"
+tokio = { version = "0.2", features = ["rt-core", "sync", "rt-threaded", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-apm-sync"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Michael Micucci <9975355+kitsuneninetails@users.noreply.github.com>", "Fernando Gonçalves <fernando.goncalves@pipefy.com> (original base code)"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,51 @@
-# Datadog apm (sync-bsed) for Rust (fork from datadog-apm)
+# Datadog apm (sync-bsed) for Rust (original fork from datadog-apm)
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 ![CI](https://github.com/kitsuneninetails/datadog-apm-rust-sync/workflows/CI/badge.svg)
 
-Based on a fork from <https://github.com/pipefy/datadog-apm-rust>.
+Credits
+-------
+Originally based on a fork from <https://github.com/pipefy/datadog-apm-rust>.
 Original code written by Fernando Gonçalves (github: <https://github.com/fhsgoncalves>).
 
-Credit and my gratitude go to the original author for the original code.  This repo only builds on top 
+Credit and my gratitude go to the original author for the original code.  This repo builds on top 
 of his hard work and research.
 
-Changes
--------
 
-As this was a fairly big change to the design and implementation, I decided to make a new repo, rather 
-than a fork, as a PR against the original would be ill-advised, as it changes some basic assumptions and design 
-decisions which I don't feel fair to impose upon the original author (his vision should guide the path the original 
-repo proceeds upon; this repo is just my vision for the original idea he came up with).
+Usage
+------
 
-This tracer has also been extended to become a Logger, allowing logs to be printed out with span and trace IDs.  This
-step also brings it closer to compatibility with rust-tracing and open-telemetry APIs.
+Add to your `Cargo.toml`:
+```toml
+tracing = "0.1"
+tracing-futures = "*"
+datadog-apm-sync = {version = "0.2", git = "http://github.com/kitsuneninetails/datadog-apm-rust-sync"}
+```
 
-Modifications made to use Hyper 0.10 and remove all Tokio/Async+Await functionality:
+In your Rust code, instantiate a DatadogTracer:
 
+```text
+# {
+    let config = Config {
+        service: "service_name".into(),
+        logging_config: Some(LoggingConfig {
+            level: Level::Debug,
+            ..LoggingConfig::default()
+        }),
+        enable_tracing: true,
+        ..Default::default()
+    };
+    let _client = DatadogTracing::new(config);
+#}
+```
+
+Then, just use the tracing library normally (with #[instrument] tags, and span! + span.enter() code) and your data
+will log with trace-id/span-id where applicable (due to the `logging_config` beign passed in; pass in `None` to disable
+the DatadogTracing as a logger) and will prepare datadog traces via the tracing::Subscriber calls (due to `enable_tracing`
+being set; set to `false` to disable the DatadogTracing as a tracing subscriber).
+
+Other Changes from Original
+------
 * Removed tokio crate.  
 * Removed all mention of async/await.
 * Changed MPSC to std::sync version rather than tokio::sync version.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ will log with trace-id/span-id where applicable (due to the `logging_config` bei
 the DatadogTracing as a logger) and will prepare datadog traces via the tracing::Subscriber calls (due to `enable_tracing`
 being set; set to `false` to disable the DatadogTracing as a tracing subscriber).
 
+Use events (event! macro) to send error information (use the keys: error_msg, error_stack, and error_type) or 
+HTTP metdata information (use http_url, http_method, and http_status_code keys).  Also, to actually force through the 
+send to Datadog, send an event:
+
+```text
+event!(tracing::Level::INFO, send_trace=true);
+```
+
 Other Changes from Original
 ------
 * Removed tokio crate.  

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,6 @@
 use crate::model::Span;
 use serde::Serialize;
-use std::{
-    collections::HashMap
-};
+use std::collections::HashMap;
 
 fn fill_meta(span: &Span, env: Option<String>) -> HashMap<String, String> {
     let mut meta = HashMap::new();
@@ -78,7 +76,7 @@ mod tests {
 
     use super::*;
     use crate::model::HttpInfo;
-    use chrono::{Utc, Duration};
+    use chrono::{Duration, Utc};
 
     use rand::Rng;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,7 @@
 use crate::model::Span;
 use serde::Serialize;
 use std::{
-    collections::HashMap,
-    time::{Duration, UNIX_EPOCH},
+    collections::HashMap
 };
 
 fn fill_meta(span: &Span, env: Option<String>) -> HashMap<String, String> {
@@ -38,10 +37,6 @@ fn fill_metrics() -> HashMap<String, f64> {
     metrics
 }
 
-fn duration_to_nanos(duration: Duration) -> u64 {
-    duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64
-}
-
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct RawSpan {
     service: String,
@@ -67,8 +62,8 @@ impl RawSpan {
             name: span.name.clone(),
             resource: span.resource.clone(),
             parent_id: span.parent_id,
-            start: duration_to_nanos(span.start.duration_since(UNIX_EPOCH).unwrap()),
-            duration: duration_to_nanos(span.duration),
+            start: span.start.timestamp_nanos() as u64,
+            duration: span.duration.num_nanoseconds().unwrap_or(0) as u64,
             error: if span.error.is_some() { 1 } else { 0 },
             r#type: "custom".to_string(),
             meta: fill_meta(&span, env.clone()),
@@ -83,7 +78,7 @@ mod tests {
 
     use super::*;
     use crate::model::HttpInfo;
-    use std::time::SystemTime;
+    use chrono::{Utc, Duration};
 
     use rand::Rng;
 
@@ -100,8 +95,8 @@ mod tests {
             trace_id: rng.gen::<u64>(),
             name: String::from("request"),
             resource: String::from("/home/v3"),
-            start: SystemTime::now(),
-            duration: Duration::from_secs(2),
+            start: Utc::now(),
+            duration: Duration::seconds(2),
             parent_id: None,
             http: Some(HttpInfo {
                 url: String::from("/home/v3/2?trace=true"),
@@ -132,8 +127,8 @@ mod tests {
             resource: span.resource.clone(),
             service: config.service.clone(),
             r#type: "custom".into(),
-            start: duration_to_nanos(span.start.duration_since(UNIX_EPOCH).unwrap()),
-            duration: duration_to_nanos(span.duration),
+            start: span.start.timestamp_nanos() as u64,
+            duration: span.duration.num_nanoseconds().unwrap_or(0) as u64,
             error: 0,
             meta,
             metrics,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,12 +1,15 @@
+use chrono::{Utc, DateTime, Duration};
 use hyper::method::Method;
 
 use hyper::header::{ContentLength, Headers};
 use log::{error, trace, warn, Level as LogLevel, Log, Record};
 use serde_json::to_string;
-use std::sync::{mpsc, Arc, Mutex, RwLock};
-
-use crate::{api::RawSpan, model::Span, LogRecord};
-use std::collections::{HashMap, LinkedList};
+use std::{
+    sync::{mpsc, Arc, Mutex, RwLock},
+    cell::RefCell,
+    collections::{HashMap, LinkedList}
+};
+use crate::{api::RawSpan, model::Span};
 
 /// Configuration settings for the client.
 #[derive(Clone, Debug)]
@@ -21,6 +24,8 @@ pub struct Config {
     pub port: String,
     /// Optional Logging Config to also set this tracer as the main logger
     pub logging_config: Option<LoggingConfig>,
+    /// Turn on tracing
+    pub enable_tracing: bool,
 }
 
 impl Default for Config {
@@ -31,6 +36,7 @@ impl Default for Config {
             port: "8126".to_string(),
             service: "".to_string(),
             logging_config: None,
+            enable_tracing: false
         }
     }
 }
@@ -55,124 +61,192 @@ impl Default for LoggingConfig {
 }
 
 #[derive(Clone, Debug)]
-enum SpanState {
-    SpanStart(u64, u64),
-    SpanEnd(Span),
-    Log(LogRecord),
+struct LogRecord {
+    pub trace_id: Option<u64>,
+    pub span_id: Option<u64>,
+    pub level: log::Level,
+    pub time: DateTime<Utc>,
+    pub msg_str: String,
+    pub module: Option<String>,
 }
 
 #[derive(Clone, Debug)]
-struct SpanStack {
-    completed_spans: Vec<Span>,
-    current_span_stack: LinkedList<u64>,
+enum EventType {
+    Error(crate::model::ErrorInfo),
+    Http(crate::model::HttpInfo),
+    Tag(String, String)
 }
 
-impl SpanStack {
+#[derive(Clone, Debug)]
+enum TraceCommand {
+    Log(LogRecord),
+    NewSpan(NewSpanData),
+    Enter(u64, u64),
+    Exit(u64, u64),
+    CloseSpan(u64),
+    Record,
+    Event(u64, EventType),
+}
+
+#[derive(Debug, Clone)]
+struct NewSpanData {
+    pub trace_id: u64,
+    pub parent_id: Option<u64>,
+    pub id: u64,
+    pub name: String,
+    pub resource: String,
+    pub start: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+struct SpanCollection {
+    completed_spans: Vec<Span>,
+    current_spans: LinkedList<Span>,
+}
+
+impl SpanCollection {
     fn new() -> Self {
-        SpanStack {
+        SpanCollection {
             completed_spans: vec![],
-            current_span_stack: LinkedList::new(),
+            current_spans: LinkedList::new(),
         }
     }
 
-    // Open a span by pushing the ID on the "current" span stack.
-    fn start_span(&mut self, id: u64) {
-        self.current_span_stack.push_back(id);
+    // Open a span by inserting the span into the "current" span map by ID.
+    fn start_span(&mut self, span: Span) {
+        self.current_spans.push_back(span);
     }
 
-    // Move span to "completed" and return the current span ID of the top of the stack (or None
-    // if it's empty and time to remove the trace).  Unless already set, automatically set the
-    // span's parent if there are still "current" spans after popping the current one (indicating
-    // that the next on the stack is the current span's "parent").
-    fn end_span(&mut self, span: Span) -> Option<u64> {
-        if self.current_span_stack.pop_back().is_some() {
-            let add_span = Span {
-                parent_id: span
-                    .parent_id
-                    .or_else(|| self.current_span_stack.back().map(|i| *i)),
-                ..span
-            };
-            self.completed_spans.push(add_span);
-        }
-        self.current_span_stack.back().map(|id| *id)
+    // Move span to "completed" based on ID.  Return if there are current spans left or not/
+    fn end_span(&mut self) -> bool {
+        self.current_spans.pop_back()
+            .map(|span| self.completed_spans.push(
+                Span {
+                    duration: Utc::now().signed_duration_since(span.start),
+                    ..span
+                }
+            ));
+        self.current_spans.is_empty()
+    }
+
+    fn err_span(&mut self, error: crate::model::ErrorInfo) {
+        self.current_spans.pop_back().map(
+            |span| self.current_spans.push_back(
+                Span {
+                    error: Some(error),
+                    ..span
+                }
+            )
+        );
+    }
+
+    fn add_http(&mut self, http: crate::model::HttpInfo) {
+        self.current_spans.pop_back().map(
+            |span| self.current_spans.push_back(
+                Span {
+                    http: Some(http),
+                    ..span
+                }
+            )
+        );
+    }
+
+    fn add_tag(&mut self, k: String, v: String) {
+        self.current_spans.pop_back()
+            .map(|span| {
+                let mut tags = span.tags;
+                tags.insert(k, v);
+                self.current_spans.push_back(
+                    Span {
+                        tags,
+                        ..span
+                    }
+                )
+            });
+    }
+
+    fn drain(&mut self) -> Vec<Span> {
+        self.completed_spans.drain(..).collect()
     }
 }
 
 struct SpanStorage {
-    inner: RwLock<HashMap<u64, SpanStack>>,
-    last_span_id: Option<(u64, u64)>,
+    traces: RwLock<HashMap<u64, SpanCollection>>,
 }
 
 impl SpanStorage {
     fn new() -> Self {
         SpanStorage {
-            inner: RwLock::new(HashMap::new()),
-            last_span_id: None,
+            traces: RwLock::new(HashMap::new())
         }
     }
 
     // Either start a new trace with the span's trace ID (if there is no span already
     // pushed for that trace ID), or push the span on the "current" stack of spans for that
     // trace ID.
-    fn start_span(&mut self, trace_id: u64, span_id: u64) {
-        let mut inner = self.inner.write().unwrap();
-        if let Some(ref mut ss) = inner.get_mut(&trace_id) {
-            ss.start_span(span_id);
+    fn start_span(&mut self, span: Span) {
+        let trace_id = span.trace_id;
+        let mut inner = self.traces.write().unwrap();
+        if let Some(ss) = inner.get_mut(&trace_id) {
+            ss.start_span(span);
         } else {
-            let mut new_stack = SpanStack::new();
-            new_stack.start_span(span_id);
-            inner.insert(trace_id, new_stack);
+            let mut new_ss = SpanCollection::new();
+            new_ss.start_span(span);
+            inner.insert(trace_id, new_ss);
         }
-        self.last_span_id = Some((trace_id, span_id));
     }
 
-    // Check if there's a trace for this span's trace ID.  If so, pop the span (which will send
-    // the trace if there are no more spans).  If the current span list is empty after the
-    // pop, then pop the entire SpanStack and return it (consuming so we can free memory).
-    fn end_span(&mut self, span: Span) -> Option<SpanStack> {
-        let trace_id = span.trace_id;
-        self.last_span_id = {
-            let mut inner = self.inner.write().unwrap();
-            if let Some(ref mut ss) = inner.get_mut(&trace_id) {
-                ss.end_span(span)
+    /// End a span and possibly return the drained trace data if it was the last span on the stack
+    fn end_span(&mut self, trace_id: u64) -> Option<Vec<Span>>{
+        let mut inner = self.traces.write().unwrap();
+        if let Some(ref mut ss) = inner.get_mut(&trace_id) {
+            if ss.end_span() {
+                Some(ss.drain())
             } else {
-                return None;
+                None
             }
-        }
-        .map(|id| (trace_id, id));
-
-        if self.last_span_id.is_none() {
-            self.inner.write().unwrap().remove(&trace_id)
         } else {
             None
         }
     }
 
-    fn current_span_id(&self) -> Option<(u64, u64)> {
-        self.last_span_id
+    /// Record an error event on a span
+    fn span_record_error(&mut self, trace_id: u64, error: crate::model::ErrorInfo) {
+        let mut inner = self.traces.write().unwrap();
+        if let Some(ref mut ss) = inner.get_mut(&trace_id) {
+            ss.err_span(error)
+        }
+    }
+
+    /// Record HTTP info onto a span
+    fn span_record_http(&mut self, trace_id: u64, http: crate::model::HttpInfo) {
+        let mut inner = self.traces.write().unwrap();
+        if let Some(ref mut ss) = inner.get_mut(&trace_id) {
+            ss.add_http(http)
+        }
+    }
+
+    /// Record tag info onto a span
+    fn span_record_tag(&mut self, trace_id: u64, key: String, value: String) {
+        let mut inner = self.traces.write().unwrap();
+        if let Some(ref mut ss) = inner.get_mut(&trace_id) {
+            ss.add_tag(key, value)
+        }
     }
 }
 
 fn trace_server_loop(
     client: DdAgentClient,
-    buffer_receiver: mpsc::Receiver<SpanState>,
+    buffer_receiver: mpsc::Receiver<TraceCommand>,
     log_config: Option<LoggingConfig>,
 ) {
-    let mut storage = SpanStorage::new();
+    let storage = RwLock::new(SpanStorage::new());
 
     loop {
         let client = client.clone();
 
         match buffer_receiver.try_recv() {
-            Ok(SpanState::SpanStart(trace_id, span_id)) => {
-                storage.start_span(trace_id, span_id);
-            }
-            Ok(SpanState::SpanEnd(info)) => {
-                if let Some(stack) = storage.end_span(info) {
-                    client.send(stack);
-                }
-            }
-            Ok(SpanState::Log(record)) => {
+            Ok(TraceCommand::Log(record)) => {
                 if let Some(ref lc) = log_config {
                     let skip = record
                         .module
@@ -192,40 +266,79 @@ fn trace_server_loop(
                         .next()
                         .is_some();
                     if !skip && !body_skip {
-                        if let Some((traceid, spanid)) = storage.current_span_id() {
-                            println!(
-                                "{time} {level} [trace-id:{traceid} span-id:{spanid}] [{module}] {body}",
-                                time = record.time.format(lc.time_format.as_ref()),
-                                traceid = traceid,
-                                spanid = spanid,
-                                level = record.level,
-                                module = record.module.unwrap_or("-".to_string()),
-                                body = record.msg_str
-                            );
-                        } else {
-                            println!(
-                                "{time} {level} [{module}] {body}",
-                                time = record.time.format(lc.time_format.as_ref()),
-                                level = record.level,
-                                module = record.module.unwrap_or("-".to_string()),
-                                body = record.msg_str
-                            );
+                        match (record.trace_id, record.span_id) {
+                            (Some(tr), Some(sp)) => {
+                                println!(
+                                    "{time} {level} [trace-id:{traceid} span-id:{spanid}] [{module}] {body}",
+                                    time = record.time.format(lc.time_format.as_ref()),
+                                    traceid = tr,
+                                    spanid = sp,
+                                    level = record.level,
+                                    module = record.module.unwrap_or("-".to_string()),
+                                    body = record.msg_str
+                                );
+                            },
+                            _ =>  {
+                                println!(
+                                    "{time} {level} [{module}] {body}",
+                                    time = record.time.format(lc.time_format.as_ref()),
+                                    level = record.level,
+                                    module = record.module.unwrap_or("-".to_string()),
+                                    body = record.msg_str
+                                );
+                            }
                         }
                     }
                 }
+            }
+            Ok(TraceCommand::NewSpan(data)) => {
+                storage.write().unwrap().start_span(Span {
+                    id: data.id,
+                    trace_id: data.trace_id,
+                    tags: HashMap::new(),
+                    parent_id: data.parent_id,
+                    start: data.start,
+                    name: data.name,
+                    resource: data.resource,
+                    http: None,
+                    sql: None,
+                    error: None,
+                    duration: Duration::seconds(0),
+                });
+
+            }
+            Ok(TraceCommand::Enter(_trace_id, _id)) => {
+            }
+            Ok(TraceCommand::Exit(_trace_id, _id)) => {
+            }
+            Ok(TraceCommand::Event(trace_id, event)) => {
+                match event {
+                    EventType::Error(e) => storage.write().unwrap().span_record_error(trace_id, e),
+                    EventType::Http(h) => storage.write().unwrap().span_record_http(trace_id, h),
+                    EventType::Tag(k, v) => storage.write().unwrap().span_record_tag(trace_id, k, v),
+                }
+            }
+            Ok(TraceCommand::CloseSpan(trace_id)) => {
+                let ret = storage.write().unwrap().end_span(trace_id);
+                if let Some(stack) = ret {
+                    client.send(stack);
+                }
+            }
+            Ok(TraceCommand::Record) => {
             }
             Err(mpsc::TryRecvError::Disconnected) => {
                 warn!("Tracing channel disconnected, exiting");
                 return;
             }
-            _ => {}
+            Err(_) => {
+            }
         }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct DatadogTracing {
-    buffer_sender: Arc<Mutex<mpsc::Sender<SpanState>>>,
+    buffer_sender: Arc<Mutex<mpsc::Sender<TraceCommand>>>,
     log_config: Option<LoggingConfig>,
 }
 
@@ -254,34 +367,179 @@ impl DatadogTracing {
             let _ = log::set_boxed_logger(Box::new(tracer.clone()));
             log::set_max_level(lc.level.to_level_filter());
         }
+        if config.enable_tracing {
+            tracing::subscriber::set_global_default(tracer.clone()).unwrap();
+        }
         tracer
     }
 
-    pub fn start_span(&self, trace_id: u64, span_id: u64) -> Result<(), ()> {
+    fn send_log(&self, record: LogRecord) -> Result<(), ()> {
         self.buffer_sender
             .lock()
             .unwrap()
-            .send(SpanState::SpanStart(trace_id, span_id))
+            .send(TraceCommand::Log(record))
             .map(|_| ())
             .map_err(|_| ())
     }
 
-    pub fn end_span(&self, info: Span) -> Result<(), ()> {
+    fn send_new_span(&self, span: NewSpanData) -> Result<(), ()> {
         self.buffer_sender
             .lock()
             .unwrap()
-            .send(SpanState::SpanEnd(info))
+            .send(TraceCommand::NewSpan(span))
             .map(|_| ())
             .map_err(|_| ())
     }
 
-    pub fn send_log(&self, record: LogRecord) -> Result<(), ()> {
+    fn send_enter_span(&self, trace_id: u64, id: u64) -> Result<(), ()> {
         self.buffer_sender
             .lock()
             .unwrap()
-            .send(SpanState::Log(record))
+            .send(TraceCommand::Enter(trace_id, id))
             .map(|_| ())
             .map_err(|_| ())
+    }
+
+    fn send_exit_span(&self, trace_id: u64, id: u64) -> Result<(), ()> {
+        self.buffer_sender
+            .lock()
+            .unwrap()
+            .send(TraceCommand::Exit(trace_id, id))
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    fn send_close_span(&self, trace_id: u64) -> Result<(), ()> {
+        self.buffer_sender
+            .lock()
+            .unwrap()
+            .send(TraceCommand::CloseSpan(trace_id))
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    fn send_record(&self, _record: LogRecord) -> Result<(), ()> {
+        self.buffer_sender
+            .lock()
+            .unwrap()
+            .send(TraceCommand::Record)
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    fn send_event(&self, trace_id: u64, event: EventType) -> Result<(), ()> {
+        self.buffer_sender
+            .lock()
+            .unwrap()
+            .send(TraceCommand::Event(trace_id, event))
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+}
+
+fn log_level_to_trace_level(level: log::Level) -> tracing::Level {
+    use log::Level::*;
+    match level {
+        Error => tracing::Level::ERROR,
+        Warn => tracing::Level::WARN,
+        Info => tracing::Level::INFO,
+        Debug => tracing::Level::DEBUG,
+        Trace => tracing::Level::TRACE,
+    }
+}
+
+thread_local! {
+    static TRACE_ID: RefCell<Option<u64>> = RefCell::new(None);
+    static CURRENT_SPAN_ID: RefCell<LinkedList<u64>> = RefCell::new(LinkedList::new());
+}
+
+impl tracing::Subscriber for DatadogTracing {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        match self.log_config {
+            Some(ref lc) => log_level_to_trace_level(lc.level) >= *metadata.level(),
+            None => false
+        }
+    }
+
+    fn new_span(&self, span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        let trace_id = TRACE_ID.with(|tr| {
+            match tr.try_borrow_mut() {
+                Ok(mut tr_id) => {
+                    if let Some(t) = *tr_id {
+                        t
+                    } else {
+                        let new_trace_id = Utc::now().timestamp_nanos() as u64;
+                        tr_id.replace(new_trace_id);
+                        new_trace_id
+                    }
+                },
+                Err(_) => {
+                    Utc::now().timestamp_nanos() as u64
+                }
+            }
+        });
+        let span_id = Utc::now().timestamp_nanos() as u64 + 1;
+        let new_span = NewSpanData {
+            id: span_id,
+            trace_id,
+            parent_id: CURRENT_SPAN_ID.with(|spans| spans.borrow().back().map(|i| *i)),
+            start: Utc::now(),
+            resource: span.metadata().target().to_string(),
+            name: span.metadata().name().to_string(),
+        };
+        self.send_new_span(new_span).unwrap_or(());
+        tracing::span::Id::from_u64(span_id)
+    }
+
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, span: &tracing::span::Id, follows: &tracing::span::Id) {
+        println!("FOLLOWS FROM {:?} ====> {:?}", follows, span);
+    }
+    fn event(&self, event: &tracing::Event<'_>) {
+        println!("EVENT: {:?}", event);
+        // TRACE_ID.with(|tr|
+        //     if let Some(ref trace_id) = *tr.borrow() {
+        //         self.send_event(*trace_id, event).unwrap_or(());
+        //     }
+        // );
+    }
+    fn enter(&self, span: &tracing::span::Id) {
+        CURRENT_SPAN_ID.with(|spans|
+            match spans.try_borrow_mut() {
+                Ok(mut r) => r.push_back(span.into_u64()),
+                Err(_) => {}
+            }
+        );
+        TRACE_ID.with(|tr|
+            if let Some(ref trace_id) = *tr.borrow() {
+                self.send_enter_span(*trace_id, span.clone().into_u64()).unwrap_or(());
+            }
+        );
+    }
+    fn clone_span(&self, id: &tracing::span::Id) -> tracing::span::Id {
+        println!("CLONE SPAN: {:?}", id);
+        id.clone()
+    }
+    fn exit(&self, span: &tracing::span::Id) {
+        CURRENT_SPAN_ID.with(|spans|
+            match spans.try_borrow_mut() {
+                Ok(mut r) => r.pop_back(),
+                Err(_) => None
+            }
+        );
+        TRACE_ID.with(|tr|
+            if let Some(ref trace_id) = *tr.borrow() {
+                self.send_exit_span(*trace_id, span.clone().into_u64()).unwrap_or(());
+            }
+        );
+    }
+    fn try_close(&self, _span: tracing::span::Id) -> bool {
+        TRACE_ID.with(|tr| {
+            if let Some(ref trace_id) = *tr.borrow() {
+                self.send_close_span(*trace_id).unwrap_or(());
+            }
+        });
+        false
     }
 }
 
@@ -299,12 +557,18 @@ impl Log for DatadogTracing {
             if record.level() <= lc.level {
                 let now = chrono::Utc::now();
                 let msg_str = format!("{}", record.args());
-                let log_rec = LogRecord {
-                    level: record.level(),
-                    time: now,
-                    module: record.module_path().map(|s| s.to_string()),
-                    msg_str,
-                };
+                let log_rec = TRACE_ID.with(|tr|
+                    CURRENT_SPAN_ID.with(|sp|
+                        LogRecord {
+                            span_id: sp.borrow().back().clone().map(|i| *i),
+                            trace_id: tr.borrow().clone(),
+                            level: record.level(),
+                            time: now,
+                            module: record.module_path().map(|s| s.to_string()),
+                            msg_str,
+                        }
+                    )
+                );
                 self.send_log(log_rec).unwrap_or_else(|_| ());
             }
         }
@@ -322,9 +586,8 @@ struct DdAgentClient {
 }
 
 impl DdAgentClient {
-    fn send(self, stack: SpanStack) {
+    fn send(self, stack: Vec<Span>) {
         let spans: Vec<Vec<RawSpan>> = vec![stack
-            .completed_spans
             .into_iter()
             .map(|s| RawSpan::from_span(&s, &self.service, &self.env))
             .collect()];
@@ -357,15 +620,27 @@ impl DdAgentClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{HttpInfo, Span};
     use log::{debug, info, Level};
-    use std::collections::HashMap;
-    use std::time::{Duration, SystemTime};
 
-    use rand::Rng;
+    #[tracing::instrument]
+    async fn traced_func(id: u32) {
+        long_call(id).await;
+    }
 
-    #[test]
-    fn test_send_trace() {
+    #[tracing::instrument]
+    async fn long_call(id: u32) {
+        debug!("Waiting on I/O {}", id);
+        sleep_call();
+        info!("I/O Finished {}", id);
+    }
+
+    #[tracing::instrument]
+    fn sleep_call() {
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+    }
+
+    #[tokio::test(threaded_scheduler)]
+    async fn test_rust_tracing() {
         let config = Config {
             service: String::from("datadog_apm_test"),
             env: Some("staging-01".into()),
@@ -374,64 +649,15 @@ mod tests {
                 mod_filter: vec!["hyper", "mime"],
                 ..LoggingConfig::default()
             }),
+            enable_tracing: true,
             ..Default::default()
         };
-        let client = DatadogTracing::new(config);
-        let mut rng = rand::thread_rng();
-        let trace_id = rng.gen::<u64>();
-        let parent_span_id = rng.gen::<u64>();
-        debug!("Test before span start (should have no span-id and trace-id info");
-        let pspan = Span {
-            id: parent_span_id.clone(),
-            trace_id: trace_id.clone(),
-            name: String::from("request"),
-            resource: String::from("/home/v3"),
-            start: SystemTime::now(),
-            duration: Duration::from_secs(2),
-            parent_id: None,
-            http: Some(HttpInfo {
-                url: String::from("/home/v3/2?trace=true"),
-                method: String::from("GET"),
-                status_code: String::from("200"),
-            }),
-            error: None,
-            sql: None,
-            tags: HashMap::new(),
-        };
-        client.start_span(pspan.trace_id, pspan.id).unwrap();
+        let _client = DatadogTracing::new(config);
 
-        debug!("Test in span (should have trace-id and span-id)");
-        let span = Span {
-            id: rng.gen::<u64>(),
-            trace_id,
-            name: String::from("request_subspan"),
-            resource: String::from("/home/v3"),
-            start: SystemTime::now(),
-            duration: Duration::from_secs(2),
-            parent_id: Some(parent_span_id),
-            http: Some(HttpInfo {
-                url: String::from("/home/v3/2?trace=true"),
-                method: String::from("GET"),
-                status_code: String::from("200"),
-            }),
-            error: None,
-            sql: None,
-            tags: HashMap::new(),
-        };
-        client.start_span(span.trace_id, span.id).unwrap();
+        let f1 = tokio::spawn(async move { traced_func(1).await });
+        let f2 = tokio::spawn(async move { traced_func(2).await });
+        tokio::join!(f1, f2);
 
-        info!("Test in subspan (should have trace-id and span-id)");
-
-        trace!("Should not print because below log level");
-
-        client.end_span(span).unwrap();
-
-        error!(
-            "Test after subspan end, but still in parent span (should have trace-id and span-id)"
-        );
-        client.end_span(pspan).unwrap();
-
-        debug!("Test after last span end (should have no span-id and trace-id info");
         ::std::thread::sleep(::std::time::Duration::from_millis(1000));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -460,8 +460,8 @@ impl DatadogTracing {
 fn log_level_to_trace_level(level: log::Level) -> tracing::Level {
     use log::Level::*;
     match level {
-        Error => tracing::Level::ERROR,
-        Warn => tracing::Level::WARN,
+        Error => tracing::Level::INFO,
+        Warn => tracing::Level::INFO,
         Info => tracing::Level::INFO,
         Debug => tracing::Level::DEBUG,
         Trace => tracing::Level::TRACE,
@@ -747,7 +747,7 @@ mod tests {
         let f3 = tokio::spawn(async move { traced_error_func(3).await });
         let f4 = tokio::spawn(async move {
             traced_error_func_single_event(4).await;
-            event!(tracing::Level::INFO, send_trace=true);
+            event!(tracing::Level::INFO, send_trace = true);
         });
 
         let (r1, r2, r3, r4) = tokio::join!(f1, f2, f3, f4);

--- a/src/client.rs
+++ b/src/client.rs
@@ -397,7 +397,12 @@ impl DatadogTracing {
             log::set_max_level(lc.level.to_level_filter());
         }
         if config.enable_tracing {
-            tracing::subscriber::set_global_default(tracer.clone()).unwrap();
+            tracing::subscriber::set_global_default(tracer.clone()).unwrap_or_else(|_| {
+                warn!(
+                    "Global subscriber has already been set!  \
+                           This should only be set once in the executable."
+                )
+            });
         }
         tracer
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -710,8 +710,7 @@ mod tests {
             http_status_code = "400",
             http_method = "GET",
             custom_tag = "good",
-            custom_tag2 = "test",
-            send_trace = true
+            custom_tag2 = "test"
         );
     }
 
@@ -746,7 +745,10 @@ mod tests {
         let f1 = tokio::spawn(async move { traced_func(1).await });
         let f2 = tokio::spawn(async move { traced_func(2).await });
         let f3 = tokio::spawn(async move { traced_error_func(3).await });
-        let f4 = tokio::spawn(async move { traced_error_func_single_event(4).await });
+        let f4 = tokio::spawn(async move {
+            traced_error_func_single_event(4).await;
+            event!(tracing::Level::INFO, send_trace=true);
+        });
 
         let (r1, r2, r3, r4) = tokio::join!(f1, f2, f3, f4);
         r1.unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -464,6 +464,10 @@ thread_local! {
     static CURRENT_SPAN_ID: RefCell<LinkedList<u64>> = RefCell::new(LinkedList::new());
 }
 
+pub fn get_thread_trace_id() -> Option<u64> {
+    TRACE_ID.with(|id| id.borrow().clone())
+}
+
 pub struct EventVisitor {
     fields: Vec<(String, String)>,
 }
@@ -653,6 +657,7 @@ mod tests {
     #[tracing::instrument]
     async fn traced_func(id: u32) {
         debug!("Performing some function for id={}", id);
+        debug!("Current trace ID: {}", get_thread_trace_id().unwrap());
         long_call(id).await;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,6 @@ pub mod client;
 pub mod model;
 
 pub use crate::{
-    client::{Config, DatadogTracing, LoggingConfig, get_thread_trace_id},
+    client::{get_thread_trace_id, Config, DatadogTracing, LoggingConfig},
     model::{ErrorInfo, HttpInfo, Span, SqlInfo},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,3 @@ pub use crate::{
     client::{Config, DatadogTracing, LoggingConfig},
     model::{ErrorInfo, HttpInfo, Span, SqlInfo},
 };
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,6 @@ pub mod client;
 pub mod model;
 
 pub use crate::{
-    client::{Config, DatadogTracing, LoggingConfig},
+    client::{Config, DatadogTracing, LoggingConfig, get_thread_trace_id},
     model::{ErrorInfo, HttpInfo, Span, SqlInfo},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,3 @@ pub use crate::{
     model::{ErrorInfo, HttpInfo, Span, SqlInfo},
 };
 
-use chrono::{DateTime, Utc};
-use log::Level;
-
-#[derive(Clone, Debug)]
-pub struct LogRecord {
-    pub level: Level,
-    pub time: DateTime<Utc>,
-    pub msg_str: String,
-    pub module: Option<String>,
-}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,5 @@
+use chrono::{DateTime, Duration, Utc};
 use std::collections::HashMap;
-use chrono::{Duration, DateTime, Utc};
 
 #[derive(Debug, Clone)]
 pub struct Span {
@@ -23,11 +23,31 @@ pub struct ErrorInfo {
     pub stack: String,
 }
 
+impl Default for ErrorInfo {
+    fn default() -> Self {
+        ErrorInfo {
+            r#type: String::new(),
+            msg: String::new(),
+            stack: String::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct HttpInfo {
     pub url: String,
     pub status_code: String,
     pub method: String,
+}
+
+impl Default for HttpInfo {
+    fn default() -> Self {
+        HttpInfo {
+            url: String::new(),
+            status_code: String::new(),
+            method: String::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::time::{Duration, SystemTime};
+use chrono::{Duration, DateTime, Utc};
 
 #[derive(Debug, Clone)]
 pub struct Span {
@@ -8,7 +8,7 @@ pub struct Span {
     pub name: String,
     pub resource: String,
     pub parent_id: Option<u64>,
-    pub start: SystemTime,
+    pub start: DateTime<Utc>,
     pub duration: Duration,
     pub error: Option<ErrorInfo>,
     pub http: Option<HttpInfo>,


### PR DESCRIPTION
Removed manual activation of tracing and instead use rust tracing events
to instrument and send datadog tracing evens as a subscriber.

Also reimplemented log with support for trace-id and span-id.

Use thread local storage to account for current trace and span IDs so
that new spans get the appropriate parents.