### PR TITLE
 Change the calculation of parent spans

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use log::{error, trace, warn, Level as LogLevel, Log, Record};
 use serde_json::to_string;
 use std::{
     cell::RefCell,
-    collections::{HashMap, LinkedList},
+    collections::{HashMap, VecDeque},
     str::FromStr,
     sync::{mpsc, Arc, Mutex, RwLock},
 };
@@ -64,7 +64,6 @@ impl Default for LoggingConfig {
 #[derive(Clone, Debug)]
 struct LogRecord {
     pub trace_id: Option<u64>,
-    pub span_id: Option<u64>,
     pub level: log::Level,
     pub time: DateTime<Utc>,
     pub msg_str: String,
@@ -77,14 +76,13 @@ enum TraceCommand {
     NewSpan(NewSpanData),
     Enter(u64, u64),
     Exit(u64, u64),
-    CloseSpan(u64),
+    CloseSpan(u64, u64),
     Event(u64, Vec<(String, String)>),
 }
 
 #[derive(Debug, Clone)]
 struct NewSpanData {
     pub trace_id: u64,
-    pub parent_id: Option<u64>,
     pub id: u64,
     pub name: String,
     pub resource: String,
@@ -94,31 +92,66 @@ struct NewSpanData {
 #[derive(Clone, Debug)]
 struct SpanCollection {
     completed_spans: Vec<Span>,
-    current_spans: LinkedList<Span>,
+    current_spans: VecDeque<Span>,
+    entered_spans: VecDeque<u64>,
 }
 
 impl SpanCollection {
     fn new() -> Self {
         SpanCollection {
             completed_spans: vec![],
-            current_spans: LinkedList::new(),
+            current_spans: VecDeque::new(),
+            entered_spans: VecDeque::new(),
         }
     }
 
     // Open a span by inserting the span into the "current" span map by ID.
     fn start_span(&mut self, span: Span) {
         self.current_spans.push_back(span);
+        trace!(
+            "Start span: {:?}/{:?}",
+            self.completed_spans.iter().map(|i| i.id).collect::<Vec<u64>>(),
+            self.current_spans.iter().map(|i| i.id).collect::<Vec<u64>>()
+        );
     }
 
-    // Move span to "completed" based on ID.  Return if there are current spans left or not/
-    fn end_span(&mut self) -> bool {
-        self.current_spans.pop_back().map(|span| {
-            self.completed_spans.push(Span {
-                duration: Utc::now().signed_duration_since(span.start),
-                ..span
-            })
-        });
-        self.current_spans.is_empty()
+    // Move span to "completed" based on ID.
+    fn end_span(&mut self, span_id: u64) {
+        let pos = self.current_spans.iter().rposition(|i| i.id == span_id);
+        if let Some(i) = pos {
+            self.current_spans.remove(i).map(|span| {
+                self.completed_spans.push(Span {
+                    duration: Utc::now().signed_duration_since(span.start),
+                    ..span
+                })
+            });
+        }
+        trace!(
+            "End span: {:?}/{:?}",
+            self.completed_spans.iter().map(|i| i.id).collect::<Vec<u64>>(),
+            self.current_spans.iter().map(|i| i.id).collect::<Vec<u64>>()
+        );
+    }
+
+
+    // Enter a span (mark it on stack)
+    fn enter_span(&mut self, span_id: u64) {
+        self.entered_spans.push_back(span_id);
+        trace!("Enter span: {:?}", self.entered_spans);
+    }
+
+    // Exit a span (pop from stack)
+    fn exit_span(&mut self, span_id: u64) {
+        let pos = self.entered_spans.iter().rposition(|i| *i == span_id);
+        if let Some(i) = pos {
+            self.entered_spans.remove(i);
+        }
+        trace!("Exit span: {:?}", self.entered_spans);
+    }
+
+    /// Get the id, if present, of the most current span for this trace
+    fn current_span_id(&self) -> Option<u64> {
+        self.entered_spans.back().map(|i| *i)
     }
 
     fn err_span(&mut self, error: crate::model::ErrorInfo) {
@@ -169,18 +202,39 @@ impl SpanStorage {
     fn start_span(&mut self, span: Span) {
         let trace_id = span.trace_id;
         if let Some(ss) = self.traces.get_mut(&trace_id) {
-            ss.start_span(span);
+            let parent_id = ss.current_span_id();
+            ss.start_span(Span {
+                parent_id,
+                ..span
+            });
         } else {
             let mut new_ss = SpanCollection::new();
-            new_ss.start_span(span);
+            new_ss.start_span(Span {
+                parent_id: None,
+                ..span
+            });
             self.traces.insert(trace_id, new_ss);
         }
     }
 
     /// End a span and possibly return the drained trace data if it was the last span on the stack
-    fn end_span(&mut self, trace_id: u64) {
+    fn end_span(&mut self, trace_id: u64, span_id: u64) {
         if let Some(ref mut ss) = self.traces.get_mut(&trace_id) {
-            ss.end_span();
+            ss.end_span(span_id);
+        }
+    }
+
+    /// Enter a span for trace, and keep track so that new spans get the correct parent
+    fn enter_span(&mut self, trace_id: u64, span_id: u64) {
+        if let Some(ref mut ss) = self.traces.get_mut(&trace_id) {
+            ss.enter_span(span_id);
+        }
+    }
+
+    /// Exit a span for trace, and keep track so that new spans get the correct parent
+    fn exit_span(&mut self, trace_id: u64, span_id: u64) {
+        if let Some(ref mut ss) = self.traces.get_mut(&trace_id) {
+            ss.exit_span(span_id);
         }
     }
 
@@ -212,6 +266,11 @@ impl SpanStorage {
         if let Some(ref mut ss) = self.traces.get_mut(&trace_id) {
             ss.add_tag(key, value)
         }
+    }
+
+    /// Get the id, if present, of the most current span for the given thread
+    fn current_span_id(&self, trace_id: u64) -> Option<u64> {
+        self.traces.get(&trace_id).and_then(|s| s.current_span_id())
     }
 }
 
@@ -246,8 +305,11 @@ fn trace_server_loop(
                         .next()
                         .is_some();
                     if !skip && !body_skip {
-                        match (record.trace_id, record.span_id) {
-                            (Some(tr), Some(sp)) => {
+                        match record.trace_id
+                            .and_then(|tr| storage.read().unwrap().current_span_id(tr)
+                                .map(|sp| (tr, sp))
+                            ) {
+                            Some((tr, sp)) => {
                                 println!(
                                     "{time} {level} [trace-id:{traceid} span-id:{spanid}] [{module}] {body}",
                                     time = record.time.format(lc.time_format.as_ref()),
@@ -257,7 +319,7 @@ fn trace_server_loop(
                                     module = record.module.unwrap_or("-".to_string()),
                                     body = record.msg_str
                                 );
-                            }
+                            },
                             _ => {
                                 println!(
                                     "{time} {level} [{module}] {body}",
@@ -272,11 +334,12 @@ fn trace_server_loop(
                 }
             }
             Ok(TraceCommand::NewSpan(data)) => {
+                trace!("NEW SPAN: {:?}", data);
                 storage.write().unwrap().start_span(Span {
                     id: data.id,
                     trace_id: data.trace_id,
                     tags: HashMap::new(),
-                    parent_id: data.parent_id,
+                    parent_id: None,
                     start: data.start,
                     name: data.name,
                     resource: data.resource,
@@ -286,9 +349,17 @@ fn trace_server_loop(
                     duration: Duration::seconds(0),
                 });
             }
-            Ok(TraceCommand::Enter(_trace_id, _id)) => {}
-            Ok(TraceCommand::Exit(_trace_id, _id)) => {}
+            Ok(TraceCommand::Enter(trace_id, span_id)) => {
+                trace!("ENTER SPAN: {}/{}", trace_id, span_id);
+                storage.write().unwrap().enter_span(trace_id, span_id);
+            }
+            Ok(TraceCommand::Exit(trace_id, span_id)) => {
+                trace!("EXIT SPAN: {}/{}", trace_id, span_id);
+                storage.write().unwrap().exit_span(trace_id, span_id);
+            }
             Ok(TraceCommand::Event(trace_id, event)) => {
+                trace!("EVENT: {}/{:?}", trace_id, event);
+
                 fn to_error_info(
                     msg: Option<String>,
                     t: Option<String>,
@@ -353,8 +424,9 @@ fn trace_server_loop(
                     .into_iter()
                     .for_each(|(k, v)| storage.write().unwrap().span_record_tag(trace_id, k, v));
             }
-            Ok(TraceCommand::CloseSpan(trace_id)) => {
-                storage.write().unwrap().end_span(trace_id);
+            Ok(TraceCommand::CloseSpan(trace_id, span_id)) => {
+                trace!("CLOSE SPAN: {}/{}", trace_id, span_id);
+                storage.write().unwrap().end_span(trace_id, span_id);
             }
             Err(mpsc::TryRecvError::Disconnected) => {
                 warn!("Tracing channel disconnected, exiting");
@@ -443,11 +515,11 @@ impl DatadogTracing {
             .map_err(|_| ())
     }
 
-    fn send_close_span(&self, trace_id: u64) -> Result<(), ()> {
+    fn send_close_span(&self, trace_id: u64, span_id: u64) -> Result<(), ()> {
         self.buffer_sender
             .lock()
             .unwrap()
-            .send(TraceCommand::CloseSpan(trace_id))
+            .send(TraceCommand::CloseSpan(trace_id, span_id))
             .map(|_| ())
             .map_err(|_| ())
     }
@@ -475,7 +547,6 @@ fn log_level_to_trace_level(level: log::Level) -> tracing::Level {
 
 thread_local! {
     static TRACE_ID: RefCell<Option<u64>> = RefCell::new(None);
-    static CURRENT_SPAN_ID: RefCell<LinkedList<u64>> = RefCell::new(LinkedList::new());
 }
 
 pub fn get_thread_trace_id() -> Option<u64> {
@@ -534,7 +605,6 @@ impl tracing::Subscriber for DatadogTracing {
         let new_span = NewSpanData {
             id: span_id,
             trace_id,
-            parent_id: CURRENT_SPAN_ID.with(|spans| spans.borrow().back().map(|i| *i)),
             start: Utc::now(),
             resource: span.metadata().target().to_string(),
             name: span.metadata().name().to_string(),
@@ -559,10 +629,6 @@ impl tracing::Subscriber for DatadogTracing {
     }
 
     fn enter(&self, span: &tracing::span::Id) {
-        CURRENT_SPAN_ID.with(|spans| match spans.try_borrow_mut() {
-            Ok(mut r) => r.push_back(span.into_u64()),
-            Err(_) => {}
-        });
         TRACE_ID.with(|tr| {
             if let Some(ref trace_id) = *tr.borrow() {
                 self.send_enter_span(*trace_id, span.clone().into_u64())
@@ -572,10 +638,6 @@ impl tracing::Subscriber for DatadogTracing {
     }
 
     fn exit(&self, span: &tracing::span::Id) {
-        CURRENT_SPAN_ID.with(|spans| match spans.try_borrow_mut() {
-            Ok(mut r) => r.pop_back(),
-            Err(_) => None,
-        });
         TRACE_ID.with(|tr| {
             if let Some(ref trace_id) = *tr.borrow() {
                 self.send_exit_span(*trace_id, span.clone().into_u64())
@@ -584,10 +646,10 @@ impl tracing::Subscriber for DatadogTracing {
         });
     }
 
-    fn try_close(&self, _span: tracing::span::Id) -> bool {
+    fn try_close(&self, span: tracing::span::Id) -> bool {
         TRACE_ID.with(|tr| {
             if let Some(ref trace_id) = *tr.borrow() {
-                self.send_close_span(*trace_id).unwrap_or(());
+                self.send_close_span(*trace_id, span.into_u64()).unwrap_or(());
             }
         });
         false
@@ -608,15 +670,12 @@ impl Log for DatadogTracing {
             if record.level() <= lc.level {
                 let now = chrono::Utc::now();
                 let msg_str = format!("{}", record.args());
-                let log_rec = TRACE_ID.with(|tr| {
-                    CURRENT_SPAN_ID.with(|sp| LogRecord {
-                        span_id: sp.borrow().back().clone().map(|i| *i),
+                let log_rec = TRACE_ID.with(|tr| LogRecord {
                         trace_id: tr.borrow().clone(),
                         level: record.level(),
                         time: now,
                         module: record.module_path().map(|s| s.to_string()),
                         msg_str,
-                    })
                 });
                 self.send_log(log_rec).unwrap_or_else(|_| ());
             }
@@ -636,6 +695,7 @@ struct DdAgentClient {
 
 impl DdAgentClient {
     fn send(self, stack: Vec<Span>) {
+        trace!("Sending spans: {:?}", stack);
         let spans: Vec<Vec<RawSpan>> = vec![stack
             .into_iter()
             .map(|s| RawSpan::from_span(&s, &self.service, &self.env))
@@ -677,7 +737,6 @@ mod tests {
         debug!("Performing some function for id={}", id);
         debug!("Current trace ID: {}", get_thread_trace_id().unwrap());
         long_call(id).await;
-        event!(tracing::Level::INFO, send_trace = true)
     }
 
     #[tracing::instrument]
@@ -747,9 +806,18 @@ mod tests {
         };
         let _client = DatadogTracing::new(config);
 
-        let f1 = tokio::spawn(async move { traced_func(1).await });
-        let f2 = tokio::spawn(async move { traced_func(2).await });
-        let f3 = tokio::spawn(async move { traced_error_func(3).await });
+        let f1 = tokio::spawn(async move {
+            traced_func(1).await;
+            event!(tracing::Level::INFO, send_trace = true);
+        });
+        let f2 = tokio::spawn(async move {
+            traced_func(2).await;
+            event!(tracing::Level::INFO, send_trace = true);
+        });
+        let f3 = tokio::spawn(async move {
+            traced_error_func(3).await;
+            event!(tracing::Level::INFO, send_trace = true);
+        });
         let f4 = tokio::spawn(async move {
             traced_error_func_single_event(4).await;
             event!(tracing::Level::INFO, send_trace = true);


### PR DESCRIPTION
Add a "entered" stack to keep track of enter span/exit span in the
channel read thread rather than the sender.

This allows parent spans to be calculated based on the items in the
stack rather than solely based on enter/exit states.

* Automatically push trace parent span

Now it is no longer necessary to decide on the parent; it will
automatically be pushed when a new trace is started (first span where
span collection is empty for the given trace ID).  This parent wil be
re-calculated if all events are sent on a trace (because the current
span collection for that trace will be consumed and further create
events will create a whole new span collection, including a new parent.

Now, draining a span collection consumes it, so it can no longer be used
once the "send_trace" event is received for a trace.