### PR TITLE
Change events to specify trace ID in send_trace field

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -723,7 +723,6 @@ impl tracing::Subscriber for DatadogTracing {
         let thread_id = get_thread_id();
         let mut new_evt_visitor = HashMapVisitor::new();
         event.record(&mut new_evt_visitor);
-        trace!("Event push: {:?}", new_evt_visitor.fields);
 
         self.send_event(nanos, thread_id, new_evt_visitor.fields)
             .unwrap_or(());


### PR DESCRIPTION
To send a trace, use the "send_trace" key in an event like always, but
instead of "true" and then providing the trace_id as a separate
key/value pair, just specify the trace id as the value for "send_trace".

So:

event!(tracing::Level::INFO, send_trace=0123456);