### PR TITLE
Add unique ID generator for u64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/kitsuneninetails/datadog-apm-rust"
 chrono = "*"
 hyper = "0.10"
 filter-logger = "*"
+lazy_static = "*"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Also change how thread IDs are generated to just using a static atomic
counter, starting from 0 (32-bit).

Unique IDs are generated by using 48-bits (6 bytes) as the number of
milliseconds since epoch and a 16-bit static counter, allowing for 65k
uniqueIDs to be generated in one second.

This unique ID generator is meant to be used to generate trace IDs.

Span IDs are still generated with timestamp_nanos because they just have
to be unique per trace and not be the same as the traceID.