### PR TITLE
Remove Span HTTP-, error-specific details

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -63,8 +63,8 @@ impl RawSpan {
         env: &Option<String>,
         cfg: &ApmConfig,
     ) -> RawSpan {
-        let http_enabled = span.tags.contains_key(&"http.url".to_string());
-        let is_error = span.tags.contains_key(&"error.message".to_string());
+        let http_enabled = span.tags.contains_key("http.url");
+        let is_error = span.tags.contains_key("error.message");
         RawSpan {
             service: service.clone(),
             trace_id: span.trace_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,5 @@ pub mod model;
 
 pub use crate::{
     client::{get_thread_id, Config, DatadogTracing, LoggingConfig},
-    model::{ErrorInfo, HttpInfo, Span, SqlInfo},
+    model::{Span, SqlInfo},
 };

--- a/src/model.rs
+++ b/src/model.rs
@@ -10,44 +10,8 @@ pub struct Span {
     pub parent_id: Option<u64>,
     pub start: DateTime<Utc>,
     pub duration: Duration,
-    pub error: Option<ErrorInfo>,
-    pub http: Option<HttpInfo>,
     pub sql: Option<SqlInfo>,
     pub tags: HashMap<String, String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ErrorInfo {
-    pub r#type: String,
-    pub msg: String,
-    pub stack: String,
-}
-
-impl Default for ErrorInfo {
-    fn default() -> Self {
-        ErrorInfo {
-            r#type: String::new(),
-            msg: String::new(),
-            stack: String::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct HttpInfo {
-    pub url: String,
-    pub status_code: String,
-    pub method: String,
-}
-
-impl Default for HttpInfo {
-    fn default() -> Self {
-        HttpInfo {
-            url: String::new(),
-            status_code: String::new(),
-            method: String::new(),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Instead, just have users send the real tags in the event, rather than
trying to group the tags into http and error fields.  This ended up
trying to set them all at once, so users couldn't send http.url and
http.status_code separately, for example.