### PR TITLE
Change to use a functioning blocking client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-apm-sync"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Michael Micucci <9975355+kitsuneninetails@users.noreply.github.com>", "Fernando Gonçalves <fernando.goncalves@pipefy.com> (original base code)"]
 edition = "2018"
 license = "MIT"
@@ -15,7 +15,7 @@ futures = "0.3"
 lazy_static = "1.4.0"
 log = "0.4"
 rand = "0.7"
-reqwest = "0.11"
+attohttpc = { version = "0.16", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(async_closure)]
-
 pub mod api;
 pub mod client;
 pub mod model;


### PR DESCRIPTION
Reqwest says they use "blocking" but really they create and drop a
runtime underneath their supposed "blocking" calls, causing runtime
panics because of dropping runtimes inside another runtime.

This renders reqwest blocking completely unusable in anything but the
simplest contexts.

Instead, let's use attohttpc which is a simple, blocking client that
doesn't over-complicate what is really a simple matter.