### PR TITLE
Fix memory leak in span management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ tracing-futures = "0.2.4"
 
 [dev-dependencies]
 rand = "0.7"
+tokio = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-apm-sync"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Michael Micucci <9975355+kitsuneninetails@users.noreply.github.com>", "Fernando Gonçalves <fernando.goncalves@pipefy.com> (original base code)"]
 edition = "2018"
 license = "MIT"

--- a/src/client.rs
+++ b/src/client.rs
@@ -258,7 +258,7 @@ impl SpanStorage {
 
     /// End a span and update the current "top of the stack"
     fn end_span(&mut self, nanos: u64, span_id: SpanId) {
-        if let Some(trace_id) = self.spans_to_trace_id.get(&span_id) {
+        if let Some(trace_id) = self.spans_to_trace_id.remove(&span_id) {
             if let Some(ref mut ss) = self.traces.get_mut(&trace_id) {
                 ss.end_span(nanos, span_id);
             }
@@ -279,10 +279,12 @@ impl SpanStorage {
 
     /// Exit a span for trace, and keep track so that new spans get the correct parent
     fn exit_span(&mut self, span_id: SpanId) {
-        if let Some(trace_id) = self.spans_to_trace_id.get(&span_id) {
+        let trace_id = self.spans_to_trace_id.get(&span_id).cloned();
+        if let Some(trace_id) = trace_id {
             if let Some(ref mut ss) = self.traces.get_mut(&trace_id) {
                 ss.exit_span(span_id);
             }
+            self.remove_current_trace(trace_id);
         }
     }
 

--- a/tests/leak.rs
+++ b/tests/leak.rs
@@ -1,0 +1,38 @@
+use datadog_apm_sync::{Config, DatadogTracing, LoggingConfig};
+use log::debug;
+use tracing::{event, span};
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn test_leak() {
+    let config = Config {
+        service: String::from("datadog_apm_test"),
+        env: Some("staging-01".into()),
+        logging_config: Some(LoggingConfig {
+            level: log::Level::Warn,
+            mod_filter: vec!["hyper", "mime", "datadog_apm_sync::client"],
+            ..LoggingConfig::default()
+        }),
+        enable_tracing: true,
+        ..Default::default()
+    };
+    let _client = DatadogTracing::new(config);
+
+    let f1 = tokio::spawn(async {
+        for i in 1..100000000 {
+            leak(i).await.unwrap();
+            leak(i).await.unwrap();
+            event!(tracing::Level::INFO, send_trace = i);
+            if i % 10000 == 0 {
+                std::thread::sleep(std::time::Duration::from_secs(5));
+            }
+        }
+    });
+    f1.await.unwrap();
+}
+
+async fn leak(trace_id: u64) -> Result<(), ()> {
+    let _span = span!(tracing::Level::INFO, "leak_test", trace_id = trace_id);
+    debug!("Span");
+    Ok(())
+}


### PR DESCRIPTION
Every time a new span was created, a span id -> trace id mapping was
made to be able to figure out which trace needed to be updated when a
span was exited by a thread or ended.  However, this map was never
cleaned up, allowing it to grow indefinitely.

Fix is to remove the span id -> trace id mapping from the map once the
span is ended, as it would no longer be needed after tha tpoint (a
thread cannot exit a span if the span is ended and doesn't exist, after
all).

Another slight convern was how the system maps thread IDs to the current
trace IDs.  This mapping is necessary since threads may enter
and exit spans, depending on future execution, and different threads may
be called upon to service the same trace.  The same thread may also
service multiple traces at the same time.  Because of this, a map is
kept of which thread is currently operating on which trace (and vice
versa).  However, this map only has a single mapping from thread to
trace (and viceversa), meaning if a thread operated on a different
trace, the original mapping would be lost.  This is a problem because we
use that mapping to also remvoe the entry from the reverse lookup map,
and if that entry is erased, we cannot remove a potentially stale entry
from the trace -> thread map.  Since trace ids are always uniquely
generated, there is no chance that an existing entry would be
overwritten and cleared at any point in the future, resulting in a leak.

The solution was to just remove the mapping (forward and backward) when
a thread exits a span.  The only risk is if a thread logs or tries
to send a trace when it never entered a span.  This can only happen if
thread A exits a span and then thread B tries to log on that trace.
Theoretically, this shouldn't be possible, since "enter span" has to be
called in some way for the system to be able to end a span (and hence
send a trace), and any log has to be in a span as well, so the same rule
should also apply.

Therefore, this change should be safe and should ensure a leak doesn't
occur in the off chance that a thread swaps out mid-trace due to
async/await mechanics.