### PR TITLE
Fix logging filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-apm-sync"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Michael Micucci <9975355+kitsuneninetails@users.noreply.github.com>", "Fernando Gonçalves <fernando.goncalves@pipefy.com> (original base code)"]
 edition = "2018"
 license = "MIT"

--- a/src/client.rs
+++ b/src/client.rs
@@ -345,7 +345,7 @@ fn trace_server_loop(
                     let skip = record
                         .module
                         .as_ref()
-                        .map(|m: &String| lc.mod_filter.contains(&m.as_str()))
+                        .map(|m: &String| lc.mod_filter.iter().any(|filter| m.contains(*filter)))
                         .unwrap_or(false);
                     let body_skip = lc
                         .body_filter

--- a/tests/logging_filter.rs
+++ b/tests/logging_filter.rs
@@ -1,0 +1,51 @@
+use datadog_apm_sync::{Config, DatadogTracing, LoggingConfig};
+
+mod my_test {
+    use log::error;
+    pub fn test_log() {
+        error!("TEST");
+    }
+}
+
+mod my_test_start_with {
+    use log::error;
+    pub fn test_log() {
+        error!("TEST");
+    }
+}
+
+mod in_the_my_test_middle {
+    use log::error;
+    pub fn test_log() {
+        error!("TEST");
+    }
+}
+
+mod ends_with_my_test {
+    use log::error;
+    pub fn test_log() {
+        error!("TEST");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn test_log_filters() {
+    let config = Config {
+        service: String::from("datadog_apm_test"),
+        env: Some("staging-01".into()),
+        logging_config: Some(LoggingConfig {
+            level: log::Level::Error,
+            mod_filter: vec!["my_test"],
+            ..LoggingConfig::default()
+        }),
+        enable_tracing: true,
+        ..Default::default()
+    };
+    let _client = DatadogTracing::new(config);
+
+    my_test::test_log();
+    my_test_start_with::test_log();
+    ends_with_my_test::test_log();
+    in_the_my_test_middle::test_log();
+}


### PR DESCRIPTION
The log filter was changed to improve perforamnce, but it unfortunately
became a direct equality  check (which is rarely true) instead of a
standard "contains" check.

This has been fixed to now check for a contains on the mod filter versus
the mod line in the log event.

A test has been added, but there is no way to assert, since this is a
stdout call (from a different thread, so "gag" crate won't work).
Merely run the test and check the output manually to see that the lines
do NOT print out.