### PR TITLE
Update tracing-subscriber to the lastest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ attohttpc = { version = "0.16", default-features=false, features = ["json", "tls
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-tracing-subscriber = "0.2.4"
+tracing-subscriber = "0.3.14"
 tracing-futures = "0.2.4"
 
 [dev-dependencies]


### PR DESCRIPTION
We can update the `tracing-subscriber` crate to the latest version to remove one transitive dependency on `time 0.1.44`