### PR TITLE
Send spans upon completion

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -189,26 +189,10 @@ impl SpanCollection {
         self.parent_span.tags.insert(k, v);
     }
 
-    fn drain_current(mut self) -> Self {
-        std::mem::take(&mut self.current_spans)
-            .into_iter()
-            .for_each(|span| {
-                self.completed_spans.push(Span {
-                    duration: Utc::now().signed_duration_since(span.start),
-                    ..span
-                })
-            });
-        self
-    }
-
-    fn drain(self, end_time: DateTime<Utc>) -> Vec<Span> {
-        let parent_span = Span {
-            duration: end_time.signed_duration_since(self.parent_span.start.clone()),
-            ..self.parent_span.clone()
-        };
-        let mut ret = self.drain_current().completed_spans;
-        ret.push(parent_span);
-        ret
+    fn drain(mut self, end_time: DateTime<Utc>) -> Vec<Span> {
+        self.parent_span.duration = end_time.signed_duration_since(self.parent_span.start);
+        self.completed_spans.push(self.parent_span);
+        self.completed_spans
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use serde_json::to_string;
 use std::borrow::BorrowMut;
 use std::{
     cell::RefCell,
-    collections::{HashMap, VecDeque},
+    collections::HashMap,
     sync::{
         atomic::{AtomicU32, AtomicU8, Ordering},
         mpsc, RwLock,
@@ -130,8 +130,8 @@ struct NewSpanData {
 struct SpanCollection {
     completed_spans: Vec<Span>,
     parent_span: Span,
-    current_spans: VecDeque<Span>,
-    entered_spans: VecDeque<u64>,
+    current_spans: Vec<Span>,
+    entered_spans: Vec<u64>,
 }
 
 impl SpanCollection {
@@ -139,52 +139,46 @@ impl SpanCollection {
         SpanCollection {
             completed_spans: vec![],
             parent_span,
-            current_spans: VecDeque::new(),
-            entered_spans: VecDeque::new(),
+            current_spans: vec![],
+            entered_spans: vec![],
         }
     }
 
     // Open a span by inserting the span into the "current" span map by ID.
     fn start_span(&mut self, span: Span) {
         let parent_id = Some(self.current_span_id().unwrap_or(self.parent_span.id));
-        self.current_spans.push_back(Span { parent_id, ..span });
+        self.current_spans.push(Span { parent_id, ..span });
     }
 
     // Move span to "completed" based on ID.
-    fn end_span(&mut self, nanos: u64, span_id: SpanId) {
-        let pos = self.current_spans.iter().rposition(|i| i.id == span_id);
-        if let Some(i) = pos {
-            self.current_spans.remove(i).map(|span| {
-                self.completed_spans.push(Span {
-                    duration: Duration::nanoseconds(nanos as i64 - span.start.timestamp_nanos()),
-                    ..span
-                })
-            });
+    fn end_span(&mut self, nanos: u64) {
+        if let Some(span) = self.current_spans.pop() {
+            self.completed_spans.push(Span {
+                duration: Duration::nanoseconds(nanos as i64 - span.start.timestamp_nanos()),
+                ..span
+            })
         }
     }
 
     // Enter a span (mark it on stack)
     fn enter_span(&mut self, span_id: SpanId) {
-        self.entered_spans.push_back(span_id);
+        self.entered_spans.push(span_id);
     }
 
     // Exit a span (pop from stack)
-    fn exit_span(&mut self, span_id: SpanId) {
-        let pos = self.entered_spans.iter().rposition(|i| *i == span_id);
-        if let Some(i) = pos {
-            self.entered_spans.remove(i);
-        }
+    fn exit_span(&mut self) {
+        self.entered_spans.pop();
     }
 
     /// Get the id, if present, of the most current span for this trace
     fn current_span_id(&self) -> Option<u64> {
-        self.entered_spans.back().map(|i| *i)
+        self.entered_spans.last().copied()
     }
 
     fn add_tag(&mut self, k: String, v: String) {
-        self.current_spans.back_mut().map(|span| {
+        if let Some(span) = self.current_spans.last_mut() {
             span.tags.insert(k.clone(), v.clone());
-        });
+        }
         self.parent_span.tags.insert(k, v);
     }
 
@@ -257,7 +251,7 @@ impl SpanStorage {
     fn end_span(&mut self, nanos: u64, span_id: SpanId) {
         if let Some(trace_id) = self.spans_to_trace_id.remove(&span_id) {
             if let Some(ref mut ss) = self.traces.get_mut(&trace_id) {
-                ss.end_span(nanos, span_id);
+                ss.end_span(nanos);
             }
         }
     }
@@ -281,7 +275,7 @@ impl SpanStorage {
         let trace_id = self.spans_to_trace_id.get(&span_id).cloned();
         if let Some(trace_id) = trace_id {
             if let Some(ref mut ss) = self.traces.get_mut(&trace_id) {
-                ss.exit_span(span_id);
+                ss.exit_span();
                 if ss.entered_spans.is_empty() {
                     self.remove_current_trace(trace_id);
                 }

--- a/tests/leak.rs
+++ b/tests/leak.rs
@@ -1,6 +1,6 @@
 use datadog_apm_sync::{Config, DatadogTracing, LoggingConfig};
 use log::warn;
-use tracing::{event, span};
+use tracing::span;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
@@ -23,7 +23,6 @@ async fn test_leak() {
             let rate_limit = false; //(i % 100_000) > 99_900;
             leak(i, rate_limit).await.unwrap();
             leak(i, rate_limit).await.unwrap();
-            event!(tracing::Level::INFO, send_trace = i);
         }
     });
     f1.await.unwrap();


### PR DESCRIPTION
Send the trace/spans to datadog when the root span has ended. This removes the need to have an `event!` to trigger sending the spans to datadog.