### PR TITLE
Remove unnecessary clones on buffer_sender

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -490,7 +490,6 @@ impl DatadogTracing {
 
     fn send_log(&self, record: LogRecord) -> Result<(), ()> {
         self.buffer_sender
-            .clone()
             .send(TraceCommand::Log(record))
             .map(|_| ())
             .map_err(|_| ())
@@ -498,7 +497,6 @@ impl DatadogTracing {
 
     fn send_new_span(&self, nanos: u64, span: NewSpanData) -> Result<(), ()> {
         self.buffer_sender
-            .clone()
             .send(TraceCommand::NewSpan(nanos, span))
             .map(|_| ())
             .map_err(|_| ())
@@ -506,7 +504,6 @@ impl DatadogTracing {
 
     fn send_enter_span(&self, nanos: u64, thread_id: ThreadId, id: SpanId) -> Result<(), ()> {
         self.buffer_sender
-            .clone()
             .send(TraceCommand::Enter(nanos, thread_id, id))
             .map(|_| ())
             .map_err(|_| ())
@@ -514,7 +511,6 @@ impl DatadogTracing {
 
     fn send_exit_span(&self, nanos: u64, id: SpanId) -> Result<(), ()> {
         self.buffer_sender
-            .clone()
             .send(TraceCommand::Exit(nanos, id))
             .map(|_| ())
             .map_err(|_| ())
@@ -522,7 +518,6 @@ impl DatadogTracing {
 
     fn send_close_span(&self, nanos: u64, span_id: SpanId) -> Result<(), ()> {
         self.buffer_sender
-            .clone()
             .send(TraceCommand::CloseSpan(nanos, span_id))
             .map(|_| ())
             .map_err(|_| ())
@@ -536,7 +531,6 @@ impl DatadogTracing {
         time: DateTime<Utc>,
     ) -> Result<(), ()> {
         self.buffer_sender
-            .clone()
             .send(TraceCommand::Event(nanos, thread_id, event, time))
             .map(|_| ())
             .map_err(|_| ())


### PR DESCRIPTION
`send(&self, ...)` takes a reference to self, so there's no need to clone it when sending a message across the channel.