### PR TITLE
Remove lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/kitsuneninetails/datadog-apm-rust-sync"
 [dependencies]
 chrono = {version = "0.4.26", default-features = false, features = ["clock"] }
 crossbeam-channel = "0.5.6"
-lazy_static = "1.4.0"
 log = {version = "0.4", features = ["std"] }
 attohttpc = { version = "0.26", default-features=false, features = ["json", "tls-rustls"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,6 @@ use crate::{api::RawSpan, model::Span};
 
 use attohttpc;
 use chrono::{DateTime, Duration, TimeZone, Utc};
-use lazy_static::lazy_static;
 use log::{warn, Level as LogLevel, Log, Record};
 use serde_json::to_string;
 use std::{
@@ -554,10 +553,8 @@ fn log_level_to_trace_level(level: log::Level) -> tracing::Level {
     }
 }
 
-lazy_static! {
-    static ref UNIQUEID_COUNTER: AtomicU16 = AtomicU16::new(0);
-    static ref THREAD_COUNTER: AtomicU32 = AtomicU32::new(0);
-}
+static UNIQUEID_COUNTER: AtomicU16 = AtomicU16::new(0);
+static THREAD_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 static mut SAMPLING_RATE: Option<f64> = None;
 


### PR DESCRIPTION
`AtomicXXX::new()` was made `const` in Rust version 1.34 removing the need to use `lazy_static` when using them as statics. 