### PR TITLE
Bumps attohttpc to resolve RUSTSEC-2024-0336

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kitsuneninetails/datadog-apm-rust-sync"
 chrono = {version = "0.4.26", default-features = false, features = ["clock"] }
 crossbeam-channel = "0.5.6"
 log = {version = "0.4", features = ["std"] }
-attohttpc = { version = "0.26", default-features=false, features = ["json", "tls-rustls"] }
+attohttpc = { version = "0.28", default-features=false, features = ["json", "tls-rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
We need to update [attohttpc](https://github.com/sbstp/attohttpc/blob/v0.26.0/Cargo.toml#L27) to resolve [RUSTSEC-2024-0336](https://rustsec.org/advisories/RUSTSEC-2024-0336) for rustls.