### PR TITLE
Stop creating and setting the same span as the first span as a traceparent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-apm-sync"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Michael Micucci <9975355+kitsuneninetails@users.noreply.github.com>", "Fernando Gonçalves <fernando.goncalves@pipefy.com> (original base code)"]
 edition = "2018"
 license = "MIT"

--- a/src/client.rs
+++ b/src/client.rs
@@ -235,18 +235,7 @@ impl SpanStorage {
         if let Some(ss) = self.traces.get_mut(&trace_id) {
             ss.start_span(span);
         } else {
-            let parent_span_id = Utc::now().timestamp_nanos() as u64 + 1;
-            let parent_span = Span {
-                id: parent_span_id,
-                parent_id: None,
-                name: format!("{}-traceparent", trace_id),
-                ..span.clone()
-            };
-
-            let mut new_ss = SpanCollection::new(parent_span);
-            new_ss.start_span(span);
-
-            self.traces.insert(trace_id, new_ss);
+            self.traces.insert(trace_id, SpanCollection::new(span));
         }
     }
 


### PR DESCRIPTION
### Issue
- The current tracing client always creates a traceparent span that is the same as the first span of a trace, which causes duplication of the first and traceparent spans.

### Solution
- Set the first span as a parent span of a trace

### Log Comparison 
- I logged the SpanCollection before and after the change and compared them

#### Comparison of `test_trace_one_func_stack` test
- Before
```rust
SpanCollection {
    completed_spans: [],
    parent_span: Span {
        id: 1728534348696762001,
        trace_id: 113281227076075520,
        name: "113281227076075520-traceparent", // traceparent was set as a parent_span
        resource: "datadog_apm_sync::client::tests",
        parent_id: None,
        start: 2024-10-10T04:25:48.696726Z,
        duration: TimeDelta {
            secs: 0,
            nanos: 0,
        },
        sql: None,
        tags: {},
    },
    current_spans: [
        Span {
            id: 1728534348696726001,
            trace_id: 113281227076075520,
            name: "traced_func_no_send", // The first span was set as a child_span of traceparent
            resource: "datadog_apm_sync::client::tests",
            parent_id: Some(
                1728534348696762001,
            ),
            start: 2024-10-10T04:25:48.696726Z,
            duration: TimeDelta {
                secs: 0,
                nanos: 0,
            },
            sql: None,
            tags: {},
        },
        Span {
            id: 1728534348696775001,
            trace_id: 113281227076075520,
            name: "long_call",
            resource: "datadog_apm_sync::client::tests",
            parent_id: Some(
                1728534348696726001,
            ),
            start: 2024-10-10T04:25:48.696775Z,
            duration: TimeDelta {
                secs: 0,
                nanos: 0,
            },
            sql: None,
            tags: {},
        },
        Span {
            id: 1728534348696779001,
            trace_id: 113281227076075520,
            name: "sleep_call",
            resource: "datadog_apm_sync::client::tests",
            parent_id: Some(
                1728534348696775001,
            ),
            start: 2024-10-10T04:25:48.696779Z,
            duration: TimeDelta {
                secs: 0,
                nanos: 0,
            },
            sql: None,
            tags: {},
        },
    ],
    entered_spans: [
        1728534348696726001,
        1728534348696775001,
    ],
}
```
- After
```rust
SpanCollection {
    completed_spans: [],
    parent_span: Span {
        id: 1728534311479753001,
        trace_id: 113281224636825600,
        name: "traced_func_no_send", // first span was set as a parent span of the trace
        resource: "datadog_apm_sync::client::tests",
        parent_id: None,
        start: 2024-10-10T04:25:11.479753Z,
        duration: TimeDelta {
            secs: 0,
            nanos: 0,
        },
        sql: None,
        tags: {},
    },
    current_spans: [
        Span {
            id: 1728534311479769001,
            trace_id: 113281224636825600,
            name: "long_call",
            resource: "datadog_apm_sync::client::tests",
            parent_id: Some(
                1728534311479753001,
            ),
            start: 2024-10-10T04:25:11.479769Z,
            duration: TimeDelta {
                secs: 0,
                nanos: 0,
            },
            sql: None,
            tags: {},
        },
        Span {
            id: 1728534311479773001,
            trace_id: 113281224636825600,
            name: "sleep_call",
            resource: "datadog_apm_sync::client::tests",
            parent_id: Some(
                1728534311479769001,
            ),
            start: 2024-10-10T04:25:11.479773Z,
            duration: TimeDelta {
                secs: 0,
                nanos: 0,
            },
            sql: None,
            tags: {},
        },
    ],
    entered_spans: [
        1728534311479753001,
        1728534311479769001,
    ],
};
```