### PR TITLE
adding support to structured logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-apm-sync"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Michael Micucci <9975355+kitsuneninetails@users.noreply.github.com>", "Fernando Gonçalves <fernando.goncalves@pipefy.com> (original base code)"]
 edition = "2018"
 license = "MIT"
@@ -19,3 +19,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
+
+[features]
+json = ["log/kv", "log/kv_serde"]


### PR DESCRIPTION
This introduces a new feature, `json`, that when active will support the usage of [structured logging](https://docs.rs/log/0.4.26/log/#structured-logging).

The way the implementation works is that if there is no structured value in the log, it will log normally like it currently is logged. But if there is at least one structured value, the log will be turned into a JSON in which the main message will be the value of the `message` key.

For example:

```rust
log::info!(attribute = 1; "log here");
// would log: `{"message": "log here", "attribute": 1}`
```