### PR TITLE
Update to allow tracing loggers to log through the tracing subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-apm-sync"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Michael Micucci <9975355+kitsuneninetails@users.noreply.github.com>", "Fernando Gonçalves <fernando.goncalves@pipefy.com> (original base code)"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Datadog APM-compatible tracer and logger for Rust"
 repository = "https://github.com/kitsuneninetails/datadog-apm-rust-sync"
 
 [dependencies]
+atomic_float = "1.1"
 chrono = {version = "0.4.26", default-features = false, features = ["clock"] }
 crossbeam-channel = "0.5.6"
 log = {version = "0.4", features = ["std"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -72,7 +72,7 @@ impl RawSpan {
             name: span.name.clone(),
             resource: span.resource.clone(),
             parent_id: span.parent_id,
-            start: span.start.timestamp_nanos() as u64,
+            start: span.start.timestamp_nanos_opt().unwrap_or(0) as u64,
             duration: span.duration.num_nanoseconds().unwrap_or(0) as u64,
             error: if is_error { 1 } else { 0 },
             r#type: if http_enabled { "web" } else { "custom" }.to_string(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,12 +2,12 @@ use crate::{client::ApmConfig, model::Span};
 use serde::Serialize;
 use std::collections::HashMap;
 
-const SAMPLING_PRIORITY_KEY: &'static str = "_sampling_priority_v1";
-const ANALYTICS_SAMPLE_RATE_KEY: &'static str = "_dd1.sr.eausr";
-const _SAMPLE_RATE_METRIC_KEY: &'static str = "_sample_rate";
-const _SAMPLING_AGENT_DECISION: &'static str = "_dd.agent_psr";
-const _SAMPLING_RULE_DECISION: &'static str = "_dd.rule_psr";
-const _SAMPLING_LIMIT_DECISION: &'static str = "_dd.limit_psr";
+const SAMPLING_PRIORITY_KEY: &str = "_sampling_priority_v1";
+const ANALYTICS_SAMPLE_RATE_KEY: &str = "_dd1.sr.eausr";
+const _SAMPLE_RATE_METRIC_KEY: &str = "_sample_rate";
+const _SAMPLING_AGENT_DECISION: &str = "_dd.agent_psr";
+const _SAMPLING_RULE_DECISION: &str = "_dd.rule_psr";
+const _SAMPLING_LIMIT_DECISION: &str = "_dd.limit_psr";
 
 fn fill_meta(span: &Span, env: Option<String>) -> HashMap<String, String> {
     let mut meta = HashMap::new();
@@ -57,16 +57,11 @@ pub struct RawSpan {
 }
 
 impl RawSpan {
-    pub fn from_span(
-        span: &Span,
-        service: &String,
-        env: &Option<String>,
-        cfg: &ApmConfig,
-    ) -> RawSpan {
+    pub fn from_span(span: &Span, service: &str, env: &Option<String>, cfg: &ApmConfig) -> RawSpan {
         let http_enabled = span.tags.contains_key("http.url");
         let is_error = span.tags.contains_key("error.message");
         RawSpan {
-            service: service.clone(),
+            service: service.to_string(),
             trace_id: span.trace_id,
             span_id: span.id,
             name: span.name.clone(),
@@ -76,7 +71,7 @@ impl RawSpan {
             duration: span.duration.num_nanoseconds().unwrap_or(0) as u64,
             error: if is_error { 1 } else { 0 },
             r#type: if http_enabled { "web" } else { "custom" }.to_string(),
-            meta: fill_meta(&span, env.clone()),
+            meta: fill_meta(span, env.clone()),
             metrics: fill_metrics(cfg),
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -471,6 +471,8 @@ fn trace_server_loop(
                             time: event.time,
                             msg_str,
                             module: event.module,
+                            #[cfg(feature = "json")]
+                            key_values: HashMap::new(),
                         };
                         filter_log(&storage, lc, record);
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -687,8 +687,8 @@ impl tracing::field::Visit for HashMapVisitor {
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
         self.add_value(field, format!("{}", value));
     }
-    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {
-        // Do nothing
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.add_value(field, format!("{:?}", value));
     }
 }
 


### PR DESCRIPTION
Eliminated deprecated and unsafe warnings
Eliminated clippy errors
Json k/v logging doesn't work with new tracing logs (only with older log crate macros)
Update to version 0.7.1