### PR TITLE
Update attohttpc version to get aws-lc-rs lib instead of ring.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-apm-sync"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Michael Micucci <9975355+kitsuneninetails@users.noreply.github.com>", "Fernando Gonçalves <fernando.goncalves@pipefy.com> (original base code)"]
 edition = "2018"
 license = "MIT"
@@ -13,7 +13,7 @@ atomic_float = "1.1"
 chrono = {version = "0.4.26", default-features = false, features = ["clock"] }
 crossbeam-channel = "0.5.6"
 log = {version = "0.4", features = ["std"] }
-attohttpc = { version = "0.28", default-features=false, features = ["json", "tls-rustls"] }
+attohttpc = { version = "0.30", default-features=false, features = ["json", "tls-rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
  Updated publish version to 0.9.0