### PR TITLE
Fix structured logging

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -470,7 +470,7 @@ fn trace_server_loop(
                             msg_str,
                             module: event.module,
                             #[cfg(feature = "json")]
-                            key_values: HashMap::new(),
+                            key_values: event.fields,
                         };
                         filter_log(&storage, lc, record);
                     }


### PR DESCRIPTION
When using structured logging in `tracing`, log events store key-value pairs in `fields`, but they're not getting propagated to `LogRecord`. This PR attempts to fix that.